### PR TITLE
[Ocean3D] Fix TitleBuilder calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.23.0):
 
 Complete list:
-- Ocean3D: Fix TitleBuilder calls (#xxx)
+- Ocean3D: Fix TitleBuilder calls (#143)
 - Introduce common `TitleBuilder` class for all diagnostics (#99)
 - LatLonProfiles: dask fix (#63) and fixes for description and PDF generation (#82)
 - Global Biases: add mean value and RMSE to global bias plot (#132)


### PR DESCRIPTION
## PR description:

All TitleBuilder calls in Ocean3D diags use the argument `collection` instead of `collections`which is supported.

Close #142

## People involved:

@tovaz92 

----

 - [ ] Tests are included if a new feature is included.
 - [ ] Changelog is updated.
