### PR TITLE
[Seaice] Raise error for missing month in input data

### DIFF
--- a/aqua/diagnostics/seaice/plot_2d_seaice.py
+++ b/aqua/diagnostics/seaice/plot_2d_seaice.py
@@ -327,7 +327,7 @@ class Plot2DSeaIce:
 
         Raises a NotEnoughDataError if any requested month is missing.
         """
-        available = set(datarr.coords['month'].values)
+        available = set(datarr.coords["month"].values)
         for month in self.months:
             if month not in available:
                 raise NotEnoughDataError(f"Month {month} missing in {data_label}. Available months: {sorted(available)}")

--- a/aqua/diagnostics/seaice/seaice.py
+++ b/aqua/diagnostics/seaice/seaice.py
@@ -241,7 +241,6 @@ class SeaIce(Diagnostic):
         # return a tuple if standard deviation was computed, otherwise just the result
         return (self.result, self.result_std) if calc_std_freq else self.result
 
-
     def _compute_2d_bymethod(self, reader_kwargs: dict = {}, **kwargs):
         """
         This method computes 2D sea ice climatology for each region.
@@ -291,7 +290,6 @@ class SeaIce(Diagnostic):
 
         return self.result
 
-
     def _mask_data_bymethod(self):
         """
         Mask the data based on the specified method.
@@ -326,7 +324,6 @@ class SeaIce(Diagnostic):
 
         return method_masked_data
 
-
     def get_area_cells_and_coords(self, masked_data: xr.DataArray):
         """
         Get areacello and space coordinates
@@ -359,7 +356,6 @@ class SeaIce(Diagnostic):
             areacello = areacello[var_name]
 
         return areacello, space_coord
-
 
     def select_region_area_cell(self, areacello: xr.DataArray, region: str, drop: bool = True):
         """
@@ -464,13 +460,12 @@ class SeaIce(Diagnostic):
         """
         ensure_istype(computed_data, xr.DataArray, logger=self.logger)
 
-        if 'time' not in computed_data.dims:
+        if "time" not in computed_data.dims:
             raise ValueError(f"Cannot compute '{stat}' because 'time' dimension is missing.")
 
-        freq_map = {'monthly': 'time.month', 
-                    'annual': 'time.year'}
+        freq_map = {"monthly": "time.month", "annual": "time.year"}
 
-        stat_map = {'std', 'mean'}
+        stat_map = {"std", "mean"}
 
         if freq not in freq_map:
             self.logger.warning(f"Frequency '{freq}' not recognized. Using 'monthly'.")
@@ -484,7 +479,6 @@ class SeaIce(Diagnostic):
 
         grouped = computed_data.groupby(freq_map[freq])
         return getattr(grouped, stat)("time")
-
 
     def _compute_seasonal_cycle(self, monthly_data):
         """


### PR DESCRIPTION
PR for better error handling when input data does not have the months that the diagnostic is intended to plot in seaice bias.
For instance, if given first two month, the default months are [3, 9] so diagnostic will fail. Better to do a check and return a specific error for this to the user.

Linked to failing condition found at [https://github.com/DestinE-Climate-DT/AQUA/issues/2670#issuecomment-3909472611](https://github.com/DestinE-Climate-DT/AQUA/issues/2670#issuecomment-3909472611)

----

 - [ ] Tests are included if a new feature is included.
 - [ ] Changelog is updated.
