### PR TITLE
restore correct aqua pin in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 core = [
-    "aqua-core==1.0.0a4"
+    "aqua-core>=1.0.0a4"
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
## PR description:

Restore the correct pin in pyproject with '>='
