### PR TITLE
[Lint]`ruff` formatter and pre-commit 

### DIFF
--- a/.github/workflows/aqua-diagnostics-test-reusable.yml
+++ b/.github/workflows/aqua-diagnostics-test-reusable.yml
@@ -195,18 +195,14 @@ jobs:
       # ========================================
       # 4. LINTING
       # ========================================
-      - name: Install Flake8
-        run: python -m pip install flake8
-      
-      - name: Lint with flake8
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Check code formatting with pre-commit
         if: ${{ inputs.install-mode == 'local' || inputs.install-mode == 'cross-check' }}
         run: |
-          # compile code to check for syntax errors
-          python -W error -m compileall -f -q AQUA-diagnostics/aqua
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 AQUA-diagnostics --count --select=E9,F63,F7,F82,B,B9 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 AQUA-diagnostics --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=__init__.py
+          cd AQUA-diagnostics
+          pre-commit run --all-files
       
       # ========================================
       # 5. INSTALL AQUA (PyPI mode)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+-   repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+    -   id: black

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -23,6 +23,8 @@ dependencies:
   - imagemagick
   - healpy
   - pip:
+    - pre-commit
+    - black
     - -e ../AQUA
     - -e ./frontier-diagnostics/tropical_cyclones/ # pip install -e of tropical cyclones
     - -e ./frontier-diagnostics/tropical_rainfall/ # pip install -e of tropical_rainfall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ minimal = [
 dev = [
     "aqua-diagnostics[docs]",
     "aqua-diagnostics[notebooks]",
-    "aqua-diagnostics[tests]"
+    "aqua-diagnostics[tests]",
+    "black",
+    "pre-commit"
 ]
 all = [
     "aqua-diagnostics[core]",
@@ -127,3 +129,7 @@ omit = [
     "aqua/diagnostics/dummy"
     ]
 
+[tool.black]
+line-length = 127
+target-version = ['py310']
+force-exclude = '__init__\.py'


### PR DESCRIPTION
This PR aim to:
1. substitute `flake8` linter with `ruff` linter-formatter 
2. integrate `pre-commit` (consistently also with GitHub reusable actions)

in AQUA-diagnostics, link to [AQUA PR#2748](https://github.com/DestinE-Climate-DT/AQUA/pull/2748) and [AQUA issue#2738](https://github.com/DestinE-Climate-DT/AQUA/issues/2738)

----

 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool.

close #91 
