### PR TITLE
Introduce pre-commit config and ruff setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+        exclude: '(\.md$|^Makefile$)'
+    -   id: end-of-file-fixer
+    -   id: check-yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Main changes:
 4. GlobalBiases: add statistical test (Welch's t-test) to global bias statistical class
 
 Complete list:
+- Add pre-commit config and ruff setup (#215)
 - Apply ruff format (#202, #210, #209)
 - TitleBuilder: add wrapping of long titles (#199)
 - Apply ruff linting and pre-commit hooks (#198)

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -10,11 +10,11 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-    @$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-    @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ tests = [
     "pytest-xdist",
     "coverage",
     "cdo",
-    "ruff"
+    "ruff==0.15.6"
 ]
 minimal = [
     "aqua-diagnostics[core]"
@@ -128,3 +128,26 @@ omit = [
     "aqua/diagnostics/dummy",
     "aqua/diagnostics/teleconnections/mjo.py" # Temporarily disabled until MJO is integrated again.
     ]
+
+[tool.ruff]
+line-length = 127
+target-version = "py310"
+exclude = ["**/__init__.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "N"]
+ignore = [
+    "N816",
+    "E741",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/*.ipynb" = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["aqua"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true


### PR DESCRIPTION
This PR comes before and will be extended by #197 changes, it introduce the pre-commit setup file and pyproject setup for ruff  
to avoid for each developers to create the file and update the pyproject locally each time. 
This simplify running the local run of the command for both pre-commit and ruff check/format.

 - [x] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool.