### PR TITLE
[Doc] Fix doc building from import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 Unreleased in the current development version (target v0.24.0):
 
+Complete list:
+- Expose `__version__` from `aqua.core.version` module (#216)
 - ECmean: time selection is now allowed (#178)
 
 ## [v0.23.0]

--- a/aqua/diagnostics/__init__.py
+++ b/aqua/diagnostics/__init__.py
@@ -1,5 +1,6 @@
 """AQUA Diagnostics Package"""
 
+from .version import __version__
 from .teleconnections import NAO, ENSO, MJO
 from .teleconnections import PlotNAO, PlotENSO, PlotMJO
 from .timeseries import Gregory, SeasonalCycles, Timeseries, PlotTimeseries, PlotSeasonalCycles, PlotGregory
@@ -21,7 +22,7 @@ from .ocean_trends import Trends, PlotTrends
 DIAGNOSTIC_CONFIG_DIRECTORIES = ["analysis", "tools", "collections"]
 DIAGNOSTIC_TEMPLATE_DIRECTORIES = ["collections"]
 
-__all__ = ["NAO", "ENSO", "MJO",
+__all__ = ["__version__", "NAO", "ENSO", "MJO",
            "PlotNAO", "PlotENSO", "PlotMJO",
            "Gregory", "SeasonalCycles", "Timeseries",
            "PlotTimeseries", "PlotSeasonalCycles", "PlotGregory",

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -2,16 +2,19 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-import os
-import sys
+from importlib.metadata import PackageNotFoundError, version as package_version
 
-from aqua.diagnostics import __version__ as project_version
+try:
+    project_version = package_version("aqua-diagnostics")
+except PackageNotFoundError:
+    # Fallback for local/source builds where package metadata is unavailable.
+    project_version = "unknown"
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "AQUA-diagnostics"
-copyright = "2025, Climate DT Team"
+copyright = "2026, Climate DT Team"
 author = "Climate DT Team"
 version = str(project_version)
 
@@ -40,8 +43,3 @@ html_theme_options = {
     "sticky_navigation": True,
     "navigation_depth": 4,
 }
-
-# Add the path to the package root (where 'aqua' folder is located)
-# From: docs/sphinx/source/conf.py
-# To:   root of the project (3 levels up)
-sys.path.insert(0, os.path.abspath("../../.."))

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -2,13 +2,8 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-from importlib.metadata import PackageNotFoundError, version as package_version
 
-try:
-    project_version = package_version("aqua-diagnostics")
-except PackageNotFoundError:
-    # Fallback for local/source builds where package metadata is unavailable.
-    project_version = "unknown"
+from aqua.diagnostics.version import __version__ as project_version
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information


### PR DESCRIPTION
This is an attempt to fix the building of the Docs as seems that
`aqua.diagnostics` does not export `__version__` in its `__init__.py`

## Issues closed by this pull request:

Close #212 

----

 - [x] Changelog is updated.