### PR TITLE
[Lint] update pre-commit config and add usage information

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,6 @@ repos:
     -   id: check-yaml
         name: Check YAML
         description: Checks that YAML files are valid
-    -   id: check-ast
-        name: Check Valid Python
-        description: check if python file is valid
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,22 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+    -   id: check-added-large-files
+        name: No large Files
+        description: Checks that you did not unconsciously upload some enormous file
     -   id: trailing-whitespace
+        name: Trim trailing Whitespaces
+        description: Trailing whitespaces are trimmed
         exclude: '(\.md$|^Makefile$)'
     -   id: end-of-file-fixer
+        name: Fix End of File
+        description: Ensures that files end with a newline
     -   id: check-yaml
+        name: Check YAML
+        description: Checks that YAML files are valid
+    -   id: check-ast
+        name: Check Valid Python
+        description: check if python file is valid
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         name: Check Valid Python
         description: check if python file is valid
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.10
     hooks:
     -   id: ruff-check
     -   id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Main changes:
 4. GlobalBiases: add statistical test (Welch's t-test) to global bias statistical class
 
 Complete list:
-- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215)
+- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215, #220)
 - Apply ruff format (#202, #210, #209)
 - TitleBuilder: add wrapping of long titles (#199)
 - Temporarily exclude MJO test (#201)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,58 +76,64 @@ In the GitHub UI: **Actions** → **AQUA-diagnostics Cross-Check** → **Run wor
 
 ### Suggesting enhancements
 
-Enhancements of existing features or new features may be suggested by opening an issue in the AQUA-diagnostics repository. Please use the `improvements` label for existing features.
+Enhancements of existing features or new features may be suggested by opening an issue in the AQUA-diagnostics repository.
+Please use the `improvements` label for existing features.
 
-### Coding style
+### Coding style checks with Ruff and pre-commit in a Pull Request
 
-To enforce the coding style, we leverage on `pre-commit` hooks and `ruff` as a linter and formatter.
-We set the length limit of 127 characters per line. More information about the coding style chosen
-can be found in the `pyproject.toml` file.
+This project uses pre-commit hooks and Ruff as linter and formatter to enforce the coding style.
+The coding style is defined by the `pyproject.toml` file and the `pre-commit` configuration file in `.pre-commit-config.yaml`.
 
-### Manual trigger of lint and formatting checks for specific files in a Pull Request
+The pre-commit and Ruff dependencies are installed automatically when setting up
+the dev environment through the `environment-dev.yml` file.
+To check and align code changes introduced in a PR with the coding style, developers can choose between the following options:
 
-To manually trigger and align the code changes to the reference coding style, do the following steps:
+1. [Recommended option] Use `pre-commit` hooks to check and align code changes at commit time.
 
-1. Install the pre-commit hooks (if not already installed):
+
+This requires installing the `pre-commit` hooks first. From the root folder of the repository, run:
+
 ```bash
 pre-commit install
 ```
 
-2. If does not exist yet, create a file `.pre-commit-config.yaml` in the root of the repository with the following content:
+From this moment on, every time a commit is made, the `pre-commit` hooks will be run automatically to check and align
+the code changes with the coding style. If the code changes are not aligned, the commit will be rejected, and the
+proposed changes will appear as unstaged changes in the developer’s local repository.
+The developer can then review the changes, stage them again, and commit successfully.
 
-```yaml
-repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-```
-
-3. From AQUA-diagnostics root folder, manually run the pre-commit hooks:
+If, for any reason, the developer wants to disable the `pre-commit` hooks, they can run:
 ```bash
-pre-commit run --all-files
+pre-commit uninstall
 ```
 
-4. If not installed already, install `ruff` (check the version in the `.pre-commit-config.yaml` file):
-```bash
-pip install ruff==<version_number>
-```
-
-5. Run the linter fixer from the path to the file or folder that have been modified in the PR and need to be aligned to the reference coding style (it will use the rules set in the `pyproject.toml` file):
+2. Alternatively, developers can manually run the `pre-commit` hooks to check the coding style of the code changes.
+To trigger all the pre-commit hooks manually, from the root folder of the repository, run:
 
 ```bash
-ruff check --fix <file_or_folder_to_target> --no-cache
+pre-commit run -a
 ```
 
-Note:
-The extra flag `--unsafe-fix` allows Ruff to apply fixes that might change the behavior of your code, even if it is not safe to do so.  
+If the developer wants to run the pre-commit hooks only for specific file(s) or folder(s), they can run:
+```bash
+pre-commit run --files <file_or_folder_to_target>
+```
+
+Side note:
+During the manual run of the pre-commit hooks, some errors can be fixed automatically
+by Ruff. However, in some cases, Ruff may require the extra flag `--unsafe-fixes`.
+This flag allows Ruff to apply fixes that might change the behavior of your code, even when it is not safe to do so.  
 Use it with caution and review the diff!
+To run manually Ruff linter with the `--unsafe-fixes` flag:
+```bash
+ruff check --fix <file_or_folder_to_target> --no-cache --unsafe-fixes
+```
+(to run over all files, set "." as the target, from the root folder of the repository)
 
-6. Run the formatter from AQUA-diagnostics root folder:
+Then, to run the formatter manually:
+
 ```bash
 ruff format <file_or_folder_to_target> --no-cache
 ```
 
-This will format the code according to the formatting rules set in the `pyproject.toml` file.
+This manual run will also format the code according to the formatting rules defined by the `pyproject.toml` file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,13 +79,23 @@ In the GitHub UI: **Actions** → **AQUA-diagnostics Cross-Check** → **Run wor
 Enhancements of existing features or new features may be suggested by opening an issue in the AQUA-diagnostics repository.
 Please use the `improvements` label for existing features.
 
-### Coding style checks with Ruff and pre-commit in a Pull Request
+### Coding style checks with ruff and pre-commit in a Pull Request
 
-This project uses pre-commit hooks and Ruff as linter and formatter to enforce the coding style.
+This project uses pre-commit hooks and ruff as linter and formatter to enforce the coding style.
 The coding style is defined by the `pyproject.toml` file and the `pre-commit` configuration file in `.pre-commit-config.yaml`.
 
-The pre-commit and Ruff dependencies are installed automatically when setting up
+The pre-commit and ruff dependencies are installed automatically when setting up
 the dev environment through the `environment-dev.yml` file.
+The pre-commit configuration enforces two groups of checks:
+
+- **General file cleaning hooks** from `pre-commit-hooks`: large-file check, trailing whitespace trimming (except `.md` and `Makefile`), end-of-file newline fix, YAML validation, and overall Python syntax validation.
+- **Ruff hooks**: `ruff-check` and `ruff-format`.
+
+Ruff has two complementary roles in this workflow:
+
+- `ruff check` runs linting rules and reports code-quality/style violations; with `--fix` (and optionally `--unsafe-fixes`) it can also auto-fix part of them.
+- `ruff format` only applies formatting (layout/style normalization), similar to a code formatter, without running lint-rule diagnostics.
+
 To check and align code changes introduced in a PR with the coding style, developers can choose between the following options:
 
 1. [Recommended option] Use `pre-commit` hooks to check and align code changes at commit time.
@@ -121,10 +131,10 @@ pre-commit run --files <file_or_folder_to_target>
 
 Side note:
 During the manual run of the pre-commit hooks, some errors can be fixed automatically
-by Ruff. However, in some cases, Ruff may require the extra flag `--unsafe-fixes`.
-This flag allows Ruff to apply fixes that might change the behavior of your code, even when it is not safe to do so.  
+by ruff. However, in some cases, ruff may require the extra flag `--unsafe-fixes`.
+This flag allows ruff to apply fixes that might change the behavior of your code, even when it is not safe to do so.  
 Use it with caution and review the diff!
-To run manually Ruff linter with the `--unsafe-fixes` flag:
+To run manually ruff linter with the `--unsafe-fixes` flag:
 ```bash
 ruff check --fix <file_or_folder_to_target> --no-cache --unsafe-fixes
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ tests = [
     "pytest-xdist",
     "coverage",
     "cdo",
-    "ruff==0.15.6"
+    "ruff==0.15.10"
 ]
 precommit = [
     "pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,11 @@ tests = [
     "pytest-cov",
     "pytest-xdist",
     "coverage",
-    "cdo",
-    "ruff==0.15.10"
+    "cdo"
 ]
-precommit = [
-    "pre-commit"
+style = [
+    "pre-commit",
+    "ruff==0.15.10"
 ]
 minimal = [
     "aqua-diagnostics[core]"
@@ -70,13 +70,14 @@ dev = [
     "aqua-diagnostics[docs]",
     "aqua-diagnostics[notebooks]",
     "aqua-diagnostics[tests]",
-    "aqua-diagnostics[precommit]"
+    "aqua-diagnostics[style]"
 ]
 all = [
     "aqua-diagnostics[core]",
     "aqua-diagnostics[docs]",
     "aqua-diagnostics[notebooks]",
-    "aqua-diagnostics[tests]"
+    "aqua-diagnostics[tests]",
+    "aqua-diagnostics[style]"
 ]
 
 [project.urls]


### PR DESCRIPTION
Update and improve the pre-commit-config file and add updated information on how pre-commit and ruff should be used by the developers. A similar PR will be opened also in [AQUA#2815](https://github.com/DestinE-Climate-DT/AQUA/pull/2815).

 - [x] Changelog is updated.
 - [x] pyproject.toml updated.