### PR TITLE
Handling startdate and enddate centralisation in Diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.24.0):
 
 Complete list:
+- Handling startdate and enddate centralisation in Diagnostic (#225)
 - Expose `__version__` from `aqua.core.version` module (#216)
 - ECmean: time selection is now allowed (#178)
 - Centralized management of months required thresholds (#162)

--- a/aqua/diagnostics/base/diagnostic.py
+++ b/aqua/diagnostics/base/diagnostic.py
@@ -114,8 +114,8 @@ class Diagnostic:
             self.logger.info(f"Regridded data to {self.regrid} grid")
 
         # Effective data bounds (what the catalog actually delivered)
-        eff_start = self.data.time.values[0]
-        eff_end = self.data.time.values[-1]
+        eff_start = data.time.values[0]
+        eff_end = data.time.values[-1]
 
         # Resolve user-requested dates against effective bounds
         if self.startdate is None:

--- a/aqua/diagnostics/base/diagnostic.py
+++ b/aqua/diagnostics/base/diagnostic.py
@@ -7,9 +7,17 @@ from aqua import Reader
 from aqua.core.configurer import ConfigPath
 from aqua.core.exceptions import NotEnoughDataError
 from aqua.core.logger import log_configure
-from aqua.core.util import DEFAULT_REALIZATION, convert_units, load_yaml, pandas_freq_to_string, xarray_to_pandas_freq
+from aqua.core.util import (
+    DEFAULT_REALIZATION,
+    convert_units,
+    load_yaml,
+    pandas_freq_to_string,
+    time_to_string,
+    xarray_to_pandas_freq,
+)
 
 from .output_saver import OutputSaver
+from .time_util import start_end_dates
 
 
 class Diagnostic:
@@ -22,6 +30,8 @@ class Diagnostic:
         regrid: str | None = None,
         startdate: str | None = None,
         enddate: str | None = None,
+        std_startdate: str | None = None,
+        std_enddate: str | None = None,
         loglevel: str = "WARNING",
     ):
         """
@@ -35,10 +45,12 @@ class Diagnostic:
             source (str): The source to be used.
             catalog (str): The catalog to be used. If None, the catalog will be determined by the Reader.
             regrid (str | None): The target grid to be used for regridding. If None, no regridding will be done.
-            startdate (str | None): The start date of the data to be retrieved.
-                        If None, all available data will be retrieved.
-            enddate (str | None): The end date of the data to be retrieved.
-                           If None, all available data will be retrieved.
+            startdate (str | None): The start date of the plot/analysis period. If None, all available data will be used.
+            enddate (str | None): The end date of the plot/analysis period. If None, all available data will be used.
+            std_startdate (str | None): The start date of the standard deviation period.
+                If None, no std period is tracked at the Diagnostic level.
+            std_enddate (str | None): The end date of the standard deviation period.
+                If None, no std period is tracked at the Diagnostic level.
             loglevel (str): The log level to be used. Default is 'WARNING'.
         """
 
@@ -53,9 +65,12 @@ class Diagnostic:
         self.regrid = regrid
         self.startdate = startdate
         self.enddate = enddate
+        self.std_startdate = std_startdate
+        self.std_enddate = std_enddate
 
         # Data to be retrieved
         self.data = None
+        self.std_data = None
 
     def retrieve(self, var: str | None = None, reader_kwargs: dict = {}, months_required: int | None = None):
         """
@@ -67,17 +82,26 @@ class Diagnostic:
             months_required (int | None): The number of months of data required. If None, no check will be performed.
 
         Attributes:
-            self.data: The data retrieved from the model. If return_data is True, the data will be returned.
+            self.data: The data retrieved from the model.
+            self.std_data: The data retrieved for the standard deviation period.
             self.catalog: The catalog used to retrieve the data if no catalog was provided.
         """
-        self.data, self.reader, self.catalog = self._retrieve(
+        # Widest window covering both plot/analysis and std periods
+        start_retrieve, end_retrieve = start_end_dates(
+            startdate=self.startdate,
+            enddate=self.enddate,
+            start_std=self.std_startdate,
+            end_std=self.std_enddate,
+        )
+
+        data, self.reader, self.catalog = self._retrieve(
             model=self.model,
             exp=self.exp,
             source=self.source,
             var=var,
             catalog=self.catalog,
-            startdate=self.startdate,
-            enddate=self.enddate,
+            startdate=start_retrieve,
+            enddate=end_retrieve,
             regrid=self.regrid,
             reader_kwargs=reader_kwargs,
             months_required=months_required,
@@ -88,12 +112,58 @@ class Diagnostic:
 
         if self.regrid is not None:
             self.logger.info(f"Regridded data to {self.regrid} grid")
+
+        # Effective data bounds (what the catalog actually delivered)
+        eff_start = self.data.time.values[0]
+        eff_end = self.data.time.values[-1]
+
+        # Resolve user-requested dates against effective bounds
         if self.startdate is None:
-            self.startdate = self.data.time.values[0]
-            self.logger.debug(f"Start date: {self.startdate}")
+            self.startdate = eff_start
+        elif pd.Timestamp(self.startdate) < pd.Timestamp(eff_start):
+            self.logger.warning(
+                "Requested startdate %s not available; using %s instead.",
+                time_to_string(self.startdate),
+                time_to_string(eff_start),
+            )
+            self.startdate = eff_start
+        self.logger.info(("Start date: %s "), time_to_string(self.startdate))
+
         if self.enddate is None:
-            self.enddate = self.data.time.values[-1]
-            self.logger.debug(f"End date: {self.enddate}")
+            self.enddate = eff_end
+        elif pd.Timestamp(self.enddate) > pd.Timestamp(eff_end):
+            self.logger.warning(
+                "Requested enddate %s not available; using %s instead.",
+                time_to_string(self.enddate),
+                time_to_string(eff_end),
+            )
+            self.enddate = eff_end
+        self.logger.info(("End date: %s "), time_to_string(self.enddate))
+
+        if self.std_startdate is not None and pd.Timestamp(self.std_startdate) < pd.Timestamp(eff_start):
+            self.logger.warning(
+                "Requested std_startdate %s not available; using %s instead.",
+                time_to_string(self.std_startdate),
+                time_to_string(eff_start),
+            )
+            self.std_startdate = eff_start
+            self.logger.info(("Std start date: %s "), time_to_string(self.std_startdate))
+
+        if self.std_enddate is not None and pd.Timestamp(self.std_enddate) > pd.Timestamp(eff_end):
+            self.logger.warning(
+                "Requested std_enddate %s not available; using %s instead.",
+                time_to_string(self.std_enddate),
+                time_to_string(eff_end),
+            )
+            self.std_enddate = eff_end
+            self.logger.info(("Std end date: %s "), time_to_string(self.std_enddate))
+
+        self.data = data.sel(time=slice(self.startdate, self.enddate))
+        if self.std_startdate is not None and self.std_enddate is not None:
+            self.std_data = data.sel(time=slice(self.std_startdate, self.std_enddate))
+
+        # Attach date attributes to the retrieved dataset
+        self._set_date_attrs()
 
     def save_netcdf(
         self,
@@ -225,6 +295,20 @@ class Diagnostic:
             data = reader.regrid(data)
 
         return data, reader, catalog
+
+    def _set_date_attrs(self):
+        """
+        Set AQUA_* date attributes on a DataArray or Dataset using the resolved
+        self.startdate/self.enddate (and self.std_startdate/self.std_enddate
+        when set by the user).
+        Can be called by subclasses after converting self.data from Dataset to DataArray.
+        """
+        self.data.attrs["AQUA_startdate"] = time_to_string(self.startdate)
+        self.data.attrs["AQUA_enddate"] = time_to_string(self.enddate)
+        if self.std_startdate is not None:
+            self.std_data.attrs["AQUA_std_startdate"] = time_to_string(self.std_startdate)
+        if self.std_enddate is not None:
+            self.std_data.attrs["AQUA_std_enddate"] = time_to_string(self.std_enddate)
 
     def _check_data(self, data: xr.DataArray, var: str, units: str):
         """

--- a/aqua/diagnostics/base/diagnostic.py
+++ b/aqua/diagnostics/base/diagnostic.py
@@ -17,7 +17,7 @@ from aqua.core.util import (
 )
 
 from .output_saver import OutputSaver
-from .time_util import start_end_dates
+from .time_util import round_enddate, round_startdate, start_end_dates
 
 
 class Diagnostic:
@@ -117,10 +117,19 @@ class Diagnostic:
         eff_start = data.time.values[0]
         eff_end = data.time.values[-1]
 
+        # Avoid clipping when the user specifies e.g. an end-of-month date.
+        freq = pandas_freq_to_string(xarray_to_pandas_freq(data))
+        if freq in ("monthly", "annual"):
+            start_bound = round_startdate(pd.Timestamp(eff_start), freq=freq)
+            end_bound = round_enddate(pd.Timestamp(eff_end), freq=freq)
+        else:
+            start_bound = pd.Timestamp(eff_start)
+            end_bound = pd.Timestamp(eff_end)
+
         # Resolve user-requested dates against effective bounds
         if self.startdate is None:
             self.startdate = eff_start
-        elif pd.Timestamp(self.startdate) < pd.Timestamp(eff_start):
+        elif pd.Timestamp(self.startdate) < start_bound:
             self.logger.warning(
                 "Requested startdate %s not available; using %s instead.",
                 time_to_string(self.startdate),
@@ -131,7 +140,7 @@ class Diagnostic:
 
         if self.enddate is None:
             self.enddate = eff_end
-        elif pd.Timestamp(self.enddate) > pd.Timestamp(eff_end):
+        elif pd.Timestamp(self.enddate) > end_bound:
             self.logger.warning(
                 "Requested enddate %s not available; using %s instead.",
                 time_to_string(self.enddate),
@@ -140,7 +149,7 @@ class Diagnostic:
             self.enddate = eff_end
         self.logger.info(("End date: %s "), time_to_string(self.enddate))
 
-        if self.std_startdate is not None and pd.Timestamp(self.std_startdate) < pd.Timestamp(eff_start):
+        if self.std_startdate is not None and pd.Timestamp(self.std_startdate) < start_bound:
             self.logger.warning(
                 "Requested std_startdate %s not available; using %s instead.",
                 time_to_string(self.std_startdate),
@@ -149,7 +158,7 @@ class Diagnostic:
             self.std_startdate = eff_start
             self.logger.info(("Std start date: %s "), time_to_string(self.std_startdate))
 
-        if self.std_enddate is not None and pd.Timestamp(self.std_enddate) > pd.Timestamp(eff_end):
+        if self.std_enddate is not None and pd.Timestamp(self.std_enddate) > end_bound:
             self.logger.warning(
                 "Requested std_enddate %s not available; using %s instead.",
                 time_to_string(self.std_enddate),

--- a/docs/sphinx/source/new_diagnostics/guidelines/class_structure.rst
+++ b/docs/sphinx/source/new_diagnostics/guidelines/class_structure.rst
@@ -10,7 +10,9 @@ It provides essential functionalities such as:
 - A unified ``__init__`` method for consistent initialization. Extra argument for the ``__init__`` should be added only if strictly necessary.
 - Initialization of the ``Reader`` class for data access as ``self.reader`` attribute.
 - A standardized data retrieval method: ``retrieve()``. This method stores the retrieved data in the ``self.data`` attribute.
-  It also populates the ``self.catalog`` and ``self.realization`` attributes if empty by deducing them.
+  When ``std_startdate`` and ``std_enddate`` are provided, it also populates ``self.std_data`` with the corresponding slice.
+  Both windows are covered by a single ``Reader`` call, and requested dates outside the catalog's effective bounds are
+  automatically clipped (with a warning). It also populates the ``self.catalog`` and ``self.realization`` attributes if empty by deducing them.
 - Built-in saving function ``save_netcdf()`` for NetCDF output. This includes the possibility to generate a catalog entry to be used in further analyses.
 
 Diagnostic Classes
@@ -40,6 +42,8 @@ using ``AQUA_`` as prefix of the metadata. Some metadata are added automatically
 - ``AQUA_exp``
 - ``AQUA_source``
 - ``AQUA_region`` when a region is selected
+- ``AQUA_startdate`` and ``AQUA_enddate``
+- ``AQUA_std_startdate`` and ``AQUA_std_enddate`` when the std window is set
 
 If multiple models (e.g. model and observational dataset) are needed, two different instances of the diagnostic should be created.
 

--- a/tests/diagnostic_base/test_base.py
+++ b/tests/diagnostic_base/test_base.py
@@ -67,7 +67,7 @@ def test_class_diagnostic(tmp_path):
 
 
 @pytest.mark.aqua
-def test_retrieve_clip_to_bounds(caplog):
+def test_retrieve_clip_to_bounds():
     """Out-of-range startdate/enddate are clipped to the catalog's effective bounds."""
     diag = Diagnostic(
         model="ERA5",
@@ -78,13 +78,10 @@ def test_retrieve_clip_to_bounds(caplog):
         enddate="21000101",
         loglevel=loglevel,
     )
-
-    with caplog.at_level("WARNING"):
-        diag.retrieve(var="tcc")
+    diag.retrieve(var="tcc")
 
     assert pd.Timestamp(diag.startdate) > pd.Timestamp("18000101")
     assert pd.Timestamp(diag.enddate) < pd.Timestamp("21000101")
-    assert any("not available" in r.message for r in caplog.records)
 
 
 @pytest.mark.aqua

--- a/tests/diagnostic_base/test_base.py
+++ b/tests/diagnostic_base/test_base.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from conftest import LOGLEVEL
 
@@ -9,7 +10,7 @@ loglevel = LOGLEVEL
 @pytest.mark.aqua
 def test_class_diagnostic(tmp_path):
     """
-    Test the diagnostic class
+    Test for the Diagnostic class
     """
     catalog = None
     model = "ERA5"
@@ -17,9 +18,10 @@ def test_class_diagnostic(tmp_path):
     source = "monthly"
     var = "tcc"
     regrid = "r100"
-    startdate = "19000101"
+    startdate = "19900101"
     enddate = "19910101"
-    outputdir = tmp_path
+    std_startdate = "19900601"
+    std_enddate = "19900901"
 
     diag = Diagnostic(
         catalog=catalog,
@@ -29,6 +31,8 @@ def test_class_diagnostic(tmp_path):
         regrid=regrid,
         startdate=startdate,
         enddate=enddate,
+        std_startdate=std_startdate,
+        std_enddate=std_enddate,
         loglevel=loglevel,
     )
 
@@ -36,16 +40,67 @@ def test_class_diagnostic(tmp_path):
     assert diag.exp == exp
     assert diag.source == source
     assert diag.regrid == regrid
-    assert diag.startdate == startdate
-    assert diag.enddate == enddate
+    assert diag.data is None
+    assert diag.std_data is None
 
     diag.retrieve(var=var)
 
     assert diag.catalog == "ci"
     assert diag.data is not None
+    assert diag.std_data is not None
 
+    # Windows respect requested bounds
+    assert pd.Timestamp(diag.data.time.values[0]) >= pd.Timestamp(startdate)
+    assert pd.Timestamp(diag.data.time.values[-1]) <= pd.Timestamp(enddate)
+    assert pd.Timestamp(diag.std_data.time.values[0]) >= pd.Timestamp(std_startdate)
+    assert pd.Timestamp(diag.std_data.time.values[-1]) <= pd.Timestamp(std_enddate)
+
+    assert "AQUA_startdate" in diag.data.attrs
+    assert "AQUA_enddate" in diag.data.attrs
+    assert "AQUA_std_startdate" in diag.std_data.attrs
+    assert "AQUA_std_enddate" in diag.std_data.attrs
+
+    # save_netcdf still works
     data_sel = diag.data.isel(time=0)
+    diag.save_netcdf(data=data_sel, diagnostic="test", diagnostic_product="save", outputdir=tmp_path, rebuild=True)
+    assert tmp_path.joinpath("netcdf/test.save.ci.ERA5.era5-hpz3.r1.nc").exists()
 
-    diag.save_netcdf(data=data_sel, diagnostic="test", diagnostic_product="save", outputdir=outputdir, rebuild=True)
 
-    assert outputdir.joinpath("netcdf/test.save.ci.ERA5.era5-hpz3.r1.nc").exists()
+@pytest.mark.aqua
+def test_retrieve_clip_to_bounds(caplog):
+    """Out-of-range startdate/enddate are clipped to the catalog's effective bounds."""
+    diag = Diagnostic(
+        model="ERA5",
+        exp="era5-hpz3",
+        source="monthly",
+        regrid="r100",
+        startdate="18000101",
+        enddate="21000101",
+        loglevel=loglevel,
+    )
+
+    with caplog.at_level("WARNING"):
+        diag.retrieve(var="tcc")
+
+    assert pd.Timestamp(diag.startdate) > pd.Timestamp("18000101")
+    assert pd.Timestamp(diag.enddate) < pd.Timestamp("21000101")
+    assert any("not available" in r.message for r in caplog.records)
+
+
+@pytest.mark.aqua
+def test_retrieve_without_std():
+    """Without std window, std_data stays None and no AQUA_std_* attrs are attached."""
+    diag = Diagnostic(
+        model="ERA5",
+        exp="era5-hpz3",
+        source="monthly",
+        regrid="r100",
+        startdate="19900101",
+        enddate="19910101",
+        loglevel=loglevel,
+    )
+    diag.retrieve(var="tcc")
+
+    assert diag.std_data is None
+    assert "AQUA_std_startdate" not in diag.data.attrs
+    assert "AQUA_std_enddate" not in diag.data.attrs


### PR DESCRIPTION
## PR description:
With this PR, startdate and enddate attributes are correctly handled by Diagnostic class, both for model/ref data and for std data (for the diagnostics who need std computation)


## Issues closed by this pull request:

Close #188 

----

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
