### PR TITLE
[CI/CD] Add verbosity to ruff GitHub action

### DIFF
--- a/.github/workflows/aqua-diagnostics-ruff.yml
+++ b/.github/workflows/aqua-diagnostics-ruff.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: Run Ruff hooks from pre-commit config
         run: |
-          pre-commit run ruff-check --all-files
-          pre-commit run ruff-format --all-files
+          pre-commit run ruff-check --all-files -v
+          pre-commit run ruff-format --all-files -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Main changes:
 4. GlobalBiases: add statistical test (Welch's t-test) to global bias statistical class
 
 Complete list:
-- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215, #220)
+- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215, #220, #)
 - Apply ruff format (#202, #210, #209)
 - TitleBuilder: add wrapping of long titles (#199)
 - Temporarily exclude MJO test (#201)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Main changes:
 4. GlobalBiases: add statistical test (Welch's t-test) to global bias statistical class
 
 Complete list:
-- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215, #220, #)
+- Implement `Ruff` linter, formatter and `pre-commit` to CI (#197, #198, #215, #220, #226)
 - Apply ruff format (#202, #210, #209)
 - TitleBuilder: add wrapping of long titles (#199)
 - Temporarily exclude MJO test (#201)


### PR DESCRIPTION
At the moment, when the ruff-action fail, the error message is not much informative. It is much better to add some extra information to the developers in case they do not use the pre-commit hooks in advance. 
A similar PR is found in AQUA.

 - [x] Changelog is updated.