### PR TITLE
[ECmean] prevent default dir creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 Unreleased in the current development version (target v0.24.0):
 Complete list:
+- ECmean: prevent creation of default empty dirs (#263)
 - Timeseries: backporting of dashboard updates (#250)
 - Timeseries: adapt to startdate and enddate centralisation in Diagnostic, remove extend feauture (#244)
 - Dashboard porting: ECmean (#192)

--- a/aqua/diagnostics/ecmean/cli_ecmean.py
+++ b/aqua/diagnostics/ecmean/cli_ecmean.py
@@ -306,6 +306,11 @@ def main(argv=None):
     config = load_diagnostic_config(
         diagnostic="ecmean", folder="tools", config=None, default_config=ecmean_config.get("config_file"), loglevel=loglevel
     )
+
+    # this prevents ecmean from creating its own dirs
+    config["dirs"]["tab"] = os.path.join(outputdir, "yml")
+    config["dirs"]["fig"] = os.path.join(outputdir, "pdf")
+
     # this is required to access the predefined areas and masks
     config["dirs"]["exp"] = ecmeandir
     logger.debug("Default config file: %s", config)
@@ -402,7 +407,6 @@ def main(argv=None):
                     config=config,
                     interface=interface,
                     loglevel=loglevel,
-                    outputdir=outputdir,
                     xdataset=data,
                     title=title,
                 )
@@ -416,7 +420,6 @@ def main(argv=None):
                     config=config,
                     interface=interface,
                     loglevel=loglevel,
-                    outputdir=outputdir,
                     xdataset=data,
                     title=title,
                 )

--- a/aqua/diagnostics/ecmean/cli_ecmean.py
+++ b/aqua/diagnostics/ecmean/cli_ecmean.py
@@ -16,7 +16,14 @@ from aqua import __version__ as aquaversion
 from aqua.core.configurer import ConfigPath
 from aqua.core.exceptions import NoDataError, NotEnoughDataError
 from aqua.core.logger import log_configure
-from aqua.core.util import get_arg, lat_to_phrase, pandas_freq_to_string, strlist_to_phrase, xarray_to_pandas_freq
+from aqua.core.util import (
+    get_arg,
+    lat_to_phrase,
+    pandas_freq_to_string,
+    strlist_to_phrase,
+    to_list,
+    xarray_to_pandas_freq,
+)
 from aqua.diagnostics import GlobalMean, PerformanceIndices
 from aqua.diagnostics.base import (
     OutputSaver,
@@ -309,7 +316,11 @@ def main(argv=None):
 
     # this prevents ecmean from creating its own dirs
     config["dirs"]["tab"] = os.path.join(outputdir, "yml")
-    config["dirs"]["fig"] = os.path.join(outputdir, "pdf")
+    if save_format:
+        config["dirs"]["fig"] = os.path.join(outputdir, to_list(save_format)[0])
+    else:
+        # this will create an empy pdf directory if no figures are produced
+        config["dirs"]["fig"] = os.path.join(outputdir, "pdf")
 
     # this is required to access the predefined areas and masks
     config["dirs"]["exp"] = ecmeandir


### PR DESCRIPTION
## PR description:

This prevents ECmean from creating empty PDF and YAML directories

## Issues closed by this pull request:

Close #258 

 - [x] Changelog is updated.
