### PR TITLE
Centralized reader kwarg

### DIFF
--- a/aqua/diagnostics/base/cli_base.py
+++ b/aqua/diagnostics/base/cli_base.py
@@ -125,12 +125,12 @@ class DiagnosticCLI:
         if self.enddate:
             self.logger.info("End date is set to %s", self.enddate)
 
-        # Realization option and reader_kwargs
-        self.reader_kwargs = self.config_dict.get("datasets", [{}])[0].get("reader_kwargs") or {}
-        self.realization = get_arg(self.args, "realization", None)
-        if self.realization:
-            self.logger.info("Realization option is set to: %s", self.realization)
-            self.reader_kwargs.update({"realization": self.realization})
+        # # Realization option and reader_kwargs
+        # self.reader_kwargs = self.config_dict.get("datasets", [{}])[0].get("reader_kwargs") or {}
+        # self.realization = get_arg(self.args, "realization", None)
+        # if self.realization:
+        #     self.logger.info("Realization option is set to: %s", self.realization)
+        #     self.reader_kwargs.update({"realization": self.realization})
 
         # Output options
         output_config = self.config_dict.get("output", {})
@@ -154,6 +154,7 @@ class DiagnosticCLI:
             "regrid": dataset.get("regrid") or self.regrid,
             "startdate": dataset.get("startdate") or self.startdate,
             "enddate": dataset.get("enddate") or self.enddate,
+            "reader_kwargs": dataset.get("reader_kwargs", {}) or self.reader_kwargs,
         }
 
     def reference_args(self, reference):
@@ -171,6 +172,7 @@ class DiagnosticCLI:
             "regrid": reference.get("regrid"),
             "startdate": reference.get("startdate"),
             "enddate": reference.get("enddate"),
+            "reader_kwargs": reference.get("reader_kwargs", {}) or self.reader_kwargs,
         }
 
     def open_dask_cluster(self):

--- a/aqua/diagnostics/base/cli_base.py
+++ b/aqua/diagnostics/base/cli_base.py
@@ -59,8 +59,6 @@ class DiagnosticCLI:
         self.regrid = None
         self.startdate = None
         self.enddate = None
-        self.realization = None
-        self.reader_kwargs = None
         self.outputdir = None
         self.rebuild = None
         self.save_format = None
@@ -125,13 +123,6 @@ class DiagnosticCLI:
         if self.enddate:
             self.logger.info("End date is set to %s", self.enddate)
 
-        # # Realization option and reader_kwargs
-        # self.reader_kwargs = self.config_dict.get("datasets", [{}])[0].get("reader_kwargs") or {}
-        # self.realization = get_arg(self.args, "realization", None)
-        # if self.realization:
-        #     self.logger.info("Realization option is set to: %s", self.realization)
-        #     self.reader_kwargs.update({"realization": self.realization})
-
         # Output options
         output_config = self.config_dict.get("output", {})
         self.outputdir = output_config.get("outputdir", "./")
@@ -154,7 +145,7 @@ class DiagnosticCLI:
             "regrid": dataset.get("regrid") or self.regrid,
             "startdate": dataset.get("startdate") or self.startdate,
             "enddate": dataset.get("enddate") or self.enddate,
-            "reader_kwargs": dataset.get("reader_kwargs", {}) or self.reader_kwargs,
+            "reader_kwargs": dataset.get("reader_kwargs", {}),
         }
 
     def reference_args(self, reference):
@@ -172,7 +163,7 @@ class DiagnosticCLI:
             "regrid": reference.get("regrid"),
             "startdate": reference.get("startdate"),
             "enddate": reference.get("enddate"),
-            "reader_kwargs": reference.get("reader_kwargs", {}) or self.reader_kwargs,
+            "reader_kwargs": reference.get("reader_kwargs", {}),
         }
 
     def open_dask_cluster(self):

--- a/aqua/diagnostics/base/util.py
+++ b/aqua/diagnostics/base/util.py
@@ -244,6 +244,12 @@ def merge_config_args(config: dict, args: argparse.Namespace, loglevel: str = "W
     datasets[0]["model"] = get_arg(args, "model", datasets[0]["model"])
     datasets[0]["exp"] = get_arg(args, "exp", datasets[0]["exp"])
     datasets[0]["source"] = get_arg(args, "source", datasets[0]["source"])
+    # If the realization argument is provided, it has to be added to the reader_kwargs dictionary
+    # of the first dataset.
+    if get_arg(args, "realization", None):
+        if "reader_kwargs" not in datasets[0]:
+            datasets[0]["reader_kwargs"] = {}
+        datasets[0]["reader_kwargs"]["realization"] = get_arg(args, "realization", None)
 
     config["output"]["outputdir"] = get_arg(args, "outputdir", config["output"]["outputdir"])
 

--- a/aqua/diagnostics/base/util.py
+++ b/aqua/diagnostics/base/util.py
@@ -135,6 +135,7 @@ def load_diagnostic_config(
 
     Args:
         diagnostic (str): diagnostic name
+        default_config (str): default config file name. If not provided, it defaults to "config-{diagnostic}.yaml".
         config (str): config argument can modify the default configuration file.
         folder (str): folder name. Default is "collections". Can be "tools" or "templates" as well.
         loglevel (str): logging level. Default is 'WARNING'.


### PR DESCRIPTION
## PR description:

Rationalize the way the `reader_kwargs` are read. Now the cli argument will override or be added to the first element of the dataset list only, similarly to the `--model` flag or others.

## Issues closed by this pull request:

Close #241 

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
