### PR TITLE
AQUA-diagnostics tests fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.24.0):
 
 Complete list:
-- Repo tests fix (#270)
 - Fallback test download from wilma (#269)
-- Jinja templates for configuration files for collections (#230)
+- Jinja templates for configuration files for collections (#230, #270)
 - Histogram: diagnostic updates (#255)
 - Seaice: Port changes from Dashboard v0.19-op  (#190)
 - ECmean: prevent creation of default empty dirs (#263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.24.0):
 
 Complete list:
+- Repo tests fix (#270)
 - Fallback test download from wilma (#269)
 - Jinja templates for configuration files for collections (#230)
 - Histogram: diagnostic updates (#255)

--- a/tests/diagnostic_base/test_base.py
+++ b/tests/diagnostic_base/test_base.py
@@ -94,8 +94,6 @@ def test_retrieve_without_std():
         regrid="r100",
         startdate="19900101",
         enddate="19910101",
-        std_startdate="19900601",
-        std_enddate="19900901",
         loglevel=loglevel,
     )
     diag.retrieve(var="tcc")

--- a/tests/diagnostic_base/test_base_util.py
+++ b/tests/diagnostic_base/test_base_util.py
@@ -113,10 +113,12 @@ def test_cluster(mock_cluster, mock_client):
 def test_load_diagnostic_config():
     """Test loading a real diagnostic configuration from the repository config path."""
 
-    default_config = REAL_CONFIG_DIR / "collections" / "jinja" / "climate_metrics" / "config-climate_metrics-gregory.j2"
+    default_config = os.path.join(
+        REAL_CONFIG_DIR, "collections", "jinja", "climate_metrics", "config-climate_metrics-gregory.j2"
+    )
     ts_dict = load_diagnostic_config(
         diagnostic="climate_metrics",
-        config=str(default_config),
+        config=default_config,
         loglevel=loglevel,
     )
 

--- a/tests/diagnostic_base/test_base_util.py
+++ b/tests/diagnostic_base/test_base_util.py
@@ -110,23 +110,13 @@ def test_cluster(mock_cluster, mock_client):
     close_cluster(client, cluster, private_cluster)
 
 
-def test_load_diagnostic_config(monkeypatch):
-    """Test loading a real diagnostic configuration from repository config path."""
+def test_load_diagnostic_config():
+    """Test loading a real diagnostic configuration from the repository config path."""
 
-    class _RepoConfigPath:
-        def __init__(self, loglevel=None):
-            self.configdir = str(REAL_CONFIG_DIR)
-
-    monkeypatch.setattr("aqua.diagnostics.base.util.ConfigPath", _RepoConfigPath)
-
-    parser = argparse.ArgumentParser()
-    parser = template_parse_arguments(parser)
-    args = parser.parse_args(["--loglevel", "DEBUG"])
+    default_config = REAL_CONFIG_DIR / "collections" / "jinja" / "climate_metrics" / "config-climate_metrics-gregory.j2"
     ts_dict = load_diagnostic_config(
         diagnostic="climate_metrics",
-        default_config="config-climate_metrics-gregory.yaml",
-        folder="collections",
-        config=args.config,
+        config=str(default_config),
         loglevel=loglevel,
     )
 


### PR DESCRIPTION
## PR description:
With @oloapinivad we figured out tests are broken on `main`. 
First, AQUA analysis worflow was not broken consequently, and only a mere test fix is necessary to solve the issue. 
More specifically, the test for `load_diagnostic_config` method of the `Diagnostic` class was not updated after #230 , that changed the configuration files folder structure, so the test is now updated accordingly with the correct `.j2` path.

----

 - [x] Tests are included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
