### PR TITLE
Telec index labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.24.0):
 
 Complete list:
+- Teleconnections: added the possibility to override default labels in the plot_index method (#273)
 - Regions config file centralization (#267)
 - Jinja templates for configuration files for collections (#230)
 - Fallback test download from wilma (#269)

--- a/aqua/diagnostics/teleconnections/plot_enso.py
+++ b/aqua/diagnostics/teleconnections/plot_enso.py
@@ -37,7 +37,7 @@ class PlotENSO(PlotBaseMixin):
         Args:
             thresh (float): Threshold for the indexes. Default is 0.5.
             labels (list): List of labels for the indexes. Default is None, in this case
-                           labels will be set by the set_labels method if not provided.
+                           labels will be set by the set_labels method.
 
         Returns:
             fig: Figure object.

--- a/aqua/diagnostics/teleconnections/plot_enso.py
+++ b/aqua/diagnostics/teleconnections/plot_enso.py
@@ -38,7 +38,7 @@ class PlotENSO(PlotBaseMixin):
             thresh (float): Threshold for the indexes. Default is 0.5.
             labels (list): List of labels for the indexes. Default is None, in this case
                            labels will be set by the set_labels method if not provided.
-        
+
         Returns:
             fig: Figure object.
             axs: Axes object.

--- a/aqua/diagnostics/teleconnections/plot_enso.py
+++ b/aqua/diagnostics/teleconnections/plot_enso.py
@@ -30,12 +30,24 @@ class PlotENSO(PlotBaseMixin):
         )
         self.logger = log_configure(log_name="PlotENSO", log_level=loglevel)
 
-    def plot_index(self, thresh: float = 0.5):
+    def plot_index(self, thresh: float = 0.5, labels: list = None):
+        """
+        Plot the indexes for the ENSO products.
+
+        Args:
+            thresh (float): Threshold for the indexes. Default is 0.5.
+            labels (list): List of labels for the indexes. Default is None, in this case
+                           labels will be set by the set_labels method if not provided.
+        
+        Returns:
+            fig: Figure object.
+            axs: Axes object.
+        """
 
         # Join the indexes in a single list
         indexes = self.indexes + self.ref_indexes
 
-        labels = super().set_labels()
+        labels = super().set_labels() if labels is None else labels
 
         title = TitleBuilder(
             diagnostic="Niño 3.4 index", model=self.models, exp=self.exps, ref_model=self.ref_models, ref_exp=self.ref_exps

--- a/aqua/diagnostics/teleconnections/plot_nao.py
+++ b/aqua/diagnostics/teleconnections/plot_nao.py
@@ -27,12 +27,22 @@ class PlotNAO(PlotBaseMixin):
         )
         self.logger = log_configure(log_name="PlotNAO", log_level=loglevel)
 
-    def plot_index(self, thresh: float = 0.0):
+    def plot_index(self, thresh: float = 0.0, labels: list = None):
+        """
+        Plot the NAO index.
 
+        Args:
+            thresh (float): Threshold for the index. Default is 0.0.
+            labels (list): List of labels for the indexes. Default is None, in which case the labels are set automatically.
+                           
+        Returns:
+            fig: Figure object.
+            axs: Axes object.
+        """
         # Join the indexes in a single list
         indexes = self.indexes + self.ref_indexes
 
-        labels = super().set_labels()
+        labels = super().set_labels() if labels is None else labels
 
         title = TitleBuilder(
             diagnostic="NAO index", model=self.models, exp=self.exps, ref_model=self.ref_models, ref_exp=self.ref_exps

--- a/aqua/diagnostics/teleconnections/plot_nao.py
+++ b/aqua/diagnostics/teleconnections/plot_nao.py
@@ -34,7 +34,7 @@ class PlotNAO(PlotBaseMixin):
         Args:
             thresh (float): Threshold for the index. Default is 0.0.
             labels (list): List of labels for the indexes. Default is None, in which case the labels are set automatically.
-                           
+
         Returns:
             fig: Figure object.
             axs: Axes object.


### PR DESCRIPTION
## PR description:

Adding the possibility to override the labels set by the diagnostics while plotting the NAO and ENSO indices. Motivated by scientific work, is a feature that I wouldn't trow away and not dangerous.

 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.