### PR TITLE
[DP] Update aqua_analysis configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.24.0):
 
 Complete list:
+- Porting of config.aqua-analysis.yaml adjustments for ocean2d (#282)
 - Porting of config.grouping.yaml adjustments (#280)
 - Teleconnections: added the possibility to override default labels in the plot_index method (#273)
 - Regions config file centralization (#267)

--- a/aqua/diagnostics/config/analysis/config.aqua-analysis-legacy.yaml
+++ b/aqua/diagnostics/config/analysis/config.aqua-analysis-legacy.yaml
@@ -104,6 +104,11 @@ diagnostics:
   ocean2d:
     biases:
       config: "${AQUA_CONFIG}/collections/legacy/ocean2d/config-ocean2d-esacci.yaml"
+    timeseries:
+      config: "${AQUA_CONFIG}/collections/legacy/ocean2d/config-ocean2d-esacci.yaml"
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/collections/legacy/ocean2d/config-ocean2d-esacci.yaml"
+
 
   ocean3d-part1:
     trends:

--- a/aqua/diagnostics/config/analysis/config.aqua-analysis.yaml
+++ b/aqua/diagnostics/config/analysis/config.aqua-analysis.yaml
@@ -106,6 +106,10 @@ diagnostics:
   ocean2d:
     biases:
       config: "${AQUA_CONFIG}/collections/jinja/ocean2d/config-ocean2d-esacci.j2"
+    timeseries:
+      config: "${AQUA_CONFIG}/collections/jinja/ocean2d/config-ocean2d-esacci.j2"
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/collections/jinja/ocean2d/config-ocean2d-esacci.j2"
 
   ocean3d-part1:
     trends:

--- a/aqua/diagnostics/config/collections/jinja/ocean2d/config-ocean2d-esacci.j2
+++ b/aqua/diagnostics/config/collections/jinja/ocean2d/config-ocean2d-esacci.j2
@@ -96,8 +96,6 @@ diagnostics:
     longterm: true
     params:
       default:
-        startdate: '{{ default.startdate }}'
-        enddate: '{{ default.enddate }}'
         std_startdate: '{{ default.std_startdate }}'
         std_enddate: '{{ default.std_enddate }}'
     variables:

--- a/aqua/diagnostics/config/collections/legacy/ocean2d/config-ocean2d-esacci.yaml
+++ b/aqua/diagnostics/config/collections/legacy/ocean2d/config-ocean2d-esacci.yaml
@@ -94,6 +94,10 @@ diagnostics:
     box_brd: true
     seasonal: true
     longterm: true
+    params:
+      default:
+        std_startdate: '19900101'
+        std_enddate: '20201231'
     variables:
       - name: 'tos'
         regions: [null]  # global


### PR DESCRIPTION
## PR description:

This updates the aqua_analysis config to align it with the changes from v0.19 for the dashboard. Only timeseres and lon_lat_profiles for ocean2d were missing


 - [x] Changelog is updated.